### PR TITLE
Fixes i2c error handling.

### DIFF
--- a/circuitpython_gizmo.py
+++ b/circuitpython_gizmo.py
@@ -146,8 +146,7 @@ class Gizmo:
             return
         try:
             self.i2c.readfrom_into(8, self.i2c_buffer)
-            self.axes.update(self.i2c_buffer)
-            self.buttons.update(self.i2c_buffer)
         except OSError:
-            self.axes.update([127] * 6)
-            self.buttons.update([0] * 12)
+            self.i2c_buffer = bytearray(([127] * 6) + ([0] * 12))
+        self.axes.update(self.i2c_buffer)
+        self.buttons.update(self.i2c_buffer)


### PR DESCRIPTION
An older version of the code passed slices of the i2c buffer to the update functions for axes and buttons. The error handling code in refresh was not changed when the update functions changed to accept the full buffer. If there was an error reading the i2c buffer, the student code would crash.